### PR TITLE
modified the weibo drop-title into lite-iconf-profile, since the web …

### DIFF
--- a/login/weibo/cookies.py
+++ b/login/weibo/cookies.py
@@ -53,7 +53,7 @@ class WeiboCookies():
         """
         try:
             return bool(
-                WebDriverWait(self.browser, 5).until(EC.presence_of_element_located((By.CLASS_NAME, 'drop-title'))))
+                WebDriverWait(self.browser, 5).until(EC.presence_of_element_located((By.CLASS_NAME, 'lite-iconf-profile'))))
         except TimeoutException:
             return False
     


### PR DESCRIPTION
In /login/weibo/cookies.py, Modified the weibo drop-title into lite-iconf-profile, since the web front source page was updated.

When type "python3 run.py" in terminal, it occured the method login_successfully cannot work well, so in the except block the statement excuted time and time: 'self.open()'  .

This is less problem for old bird, but make newbies fall in a confusion，newbies might  cry.


And I am still in confusion, I use macos, if only use the "python3 run.py", I cannot access flask web server, unless copy the api.py into the app.py and run another command in shell: "flask run". Would you give me some adivce？

Best wishes.